### PR TITLE
Remove sparse fieldset functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,10 @@ class ProfileRealizer
 end
 ```
 
-You can define special properties on attributes and relationships realizers:
+You can define special properties on relationships realizers:
 
 ``` ruby
 has_many :doctors, as: :users, includable: false
-
-has :title, selectable: false
 ```
 
 Once you've designed your resources, we just need to use them! In this example, we'll use controllers from Rails:
@@ -160,9 +158,8 @@ An adapter must provide the following interfaces:
   0. `assign_attributes_via`, describes how to write a set of properties
   0. `assign_relationships_via`, describes how to write a set of relationships
   0. `includes_via`, describes how to eager include related models
-  0. `sparse_fields_via`, describes how to only return certain fields
 
-You can also provide custom adapter interfaces like below, which will use `active_record`'s `find_many_via`, `assign_relationships_via`, `update_via`, `includes_via`, and `sparse_fields_via`:
+You can also provide custom adapter interfaces like below, which will use `active_record`'s `find_many_via`, `assign_relationships_via`, `update_via`, and `includes_via`:
 
 ``` ruby
 class PhotoRealizer

--- a/lib/jsonapi/realizer/action_spec.rb
+++ b/lib/jsonapi/realizer/action_spec.rb
@@ -26,21 +26,4 @@ RSpec.describe JSONAPI::Realizer::Action do
       end
     end
   end
-
-  describe "#fields" do
-    subject { action.fields }
-
-    context "with a two good and one bad" do
-      let(:payload) do
-        {
-          "data" => nil,
-          "fields" => "title,active_photographer.posts.comments.body,active_photographer.name"
-        }
-      end
-
-      it "contains only the two good" do
-        expect(subject).to eq([["title"], ["active_photographer", "name"]])
-      end
-    end
-  end
 end

--- a/lib/jsonapi/realizer/adapter.rb
+++ b/lib/jsonapi/realizer/adapter.rb
@@ -20,7 +20,6 @@ module JSONAPI
         raise ArgumentError, "need to provide a Adapter.find_many_via_call interface" unless instance_variable_defined?(:@find_many_via_call)
         raise ArgumentError, "need to provide a Adapter.assign_attributes_via interface" unless instance_variable_defined?(:@assign_attributes_via_call)
         raise ArgumentError, "need to provide a Adapter.assign_relationships_via interface" unless instance_variable_defined?(:@assign_relationships_via_call)
-        raise ArgumentError, "need to provide a Adapter.sparse_fields interface" unless instance_variable_defined?(:@sparse_fields_call)
         raise ArgumentError, "need to provide a Adapter.include_via interface" unless instance_variable_defined?(:@include_via_call)
       end
 
@@ -38,10 +37,6 @@ module JSONAPI
 
       def assign_relationships_via(&callback)
         @assign_relationships_via_call = callback
-      end
-
-      def sparse_fields(&callback)
-        @sparse_fields_call = callback
       end
 
       def include_via(&callback)
@@ -62,10 +57,6 @@ module JSONAPI
 
       def assign_relationships_via_call(model, relationships)
         @assign_relationships_via_call.call(model, relationships)
-      end
-
-      def sparse_fields_call(model_class, fields)
-        @sparse_fields_call.call(model_class, fields)
       end
 
       def include_via_call(model_class, includes)

--- a/lib/jsonapi/realizer/adapter/active_record.rb
+++ b/lib/jsonapi/realizer/adapter/active_record.rb
@@ -18,10 +18,6 @@ module JSONAPI
           model.assign_attributes(relationships)
         end
 
-        sparse_fields do |model_class, fields|
-          model_class.select(fields)
-        end
-
         include_via do |model_class, includes|
           model_class.includes(includes.map(&(recursively_nest = -> (chains) do
             if chains.size == 1

--- a/lib/jsonapi/realizer/adapter/memory.rb
+++ b/lib/jsonapi/realizer/adapter/memory.rb
@@ -18,10 +18,6 @@ module JSONAPI
           model.assign_attributes(relationships)
         end
 
-        sparse_fields do |model_class, fields|
-          model_class
-        end
-
         include_via do |model_class, includes|
           model_class
         end

--- a/lib/jsonapi/realizer/resource.rb
+++ b/lib/jsonapi/realizer/resource.rb
@@ -50,16 +50,12 @@ module JSONAPI
           relationships.respond_to?(name.to_sym)
         end
 
-        def valid_sparse_field?(name)
-          attribute(name).selectable if attribute(name)
-        end
-
         def valid_includes?(name)
           relationship(name).includable if relationship(name)
         end
 
-        def has(name, selectable: true)
-          attributes.public_send("#{name}=", OpenStruct.new({name: name, selectable: selectable}))
+        def has(name)
+          attributes.public_send("#{name}=", OpenStruct.new({name: name}))
         end
 
         def has_related(name, as: name, includable: true)


### PR DESCRIPTION
So right now this feature (by default) allows all attributes to be "selectable" that is to say be use in sparse fieldset functionality. The way this works for active record is using the `ActiveRecord::Relation#select()` function, which asks for that data only from the database. The way this function works is that it translates into a `SELECT` call and builds an active record object from that. This can be dangerous, obviously, so I am inclined to do one of two things:

  1. Remove the feature, sacrificing performance.
  2. Default to false, forcing developers to write a whole bunch of `selectable: true`
  3. Default to a configuration, meaning now I have to write a configuration
  4. Default to true if the field is a column, which is very implementation specific

If we keep the feature I also want to allow selectable aliases: `field :full_name, selectable: [:first_name, :last_name]`