### PR TITLE
Allow the gem to work with older versions of Rails

### DIFF
--- a/jsonapi-realizer.gemspec
+++ b/jsonapi-realizer.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "activemodel", "~> 5.1"
   spec.add_development_dependency "activerecord", "~> 5.1"
   spec.add_development_dependency "pry-doc", "~> 0.11"
-  spec.add_runtime_dependency "activesupport", "~> 5.1"
+  spec.add_runtime_dependency "activesupport", ">= 4.2"
 end

--- a/jsonapi-realizer.gemspec
+++ b/jsonapi-realizer.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "activemodel", "~> 5.1"
   spec.add_development_dependency "activerecord", "~> 5.1"
   spec.add_development_dependency "pry-doc", "~> 0.11"
-  spec.add_runtime_dependency "activesupport", "~> 4.0.0", "~> 4.1", "~> 5.0.0", "~> 5.1"
+  spec.add_runtime_dependency "activesupport", ">= 4.0.0", ">= 4.1", ">= 5.0.0", ">= 5.1"
 end

--- a/jsonapi-realizer.gemspec
+++ b/jsonapi-realizer.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "activemodel", "~> 5.1"
   spec.add_development_dependency "activerecord", "~> 5.1"
   spec.add_development_dependency "pry-doc", "~> 0.11"
-  spec.add_runtime_dependency "activesupport", ">= 4.2"
+  spec.add_runtime_dependency "activesupport", "~> 4.0.0", "~> 4.1.", "~> 5.0.0", "~> 5.1"
 end

--- a/jsonapi-realizer.gemspec
+++ b/jsonapi-realizer.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "activemodel", "~> 5.1"
   spec.add_development_dependency "activerecord", "~> 5.1"
   spec.add_development_dependency "pry-doc", "~> 0.11"
-  spec.add_runtime_dependency "activesupport", "~> 4.0.0", "~> 4.1.", "~> 5.0.0", "~> 5.1"
+  spec.add_runtime_dependency "activesupport", "~> 4.0.0", "~> 4.1", "~> 5.0.0", "~> 5.1"
 end


### PR DESCRIPTION
Instead of requiring Rails 5, we switch the dependency to be at least that of the last major Rails version: 4.2