### PR TITLE
Can realize relationships as nil (to clear them)

### DIFF
--- a/lib/jsonapi/realizer/resource.rb
+++ b/lib/jsonapi/realizer/resource.rb
@@ -239,6 +239,8 @@ module JSONAPI
       end
 
       private def as_relationship(name, value)
+        return [name, nil] if value.nil?
+
         data = value.fetch("data")
 
         relation_configuration = relation(name).realizer_class.configuration

--- a/lib/jsonapi/realizer/resource_spec.rb
+++ b/lib/jsonapi/realizer/resource_spec.rb
@@ -65,10 +65,12 @@ RSpec.describe(JSONAPI::Realizer::Resource) do
     end
 
     context "when specifying nil relationship" do
-      let(:intent) {:create}
+      let(:intent) {:update}
       let(:parameters) do
         {
+          "id" => "11",
           "data" => {
+            "id" => "11",
             "type" => "photos",
             "relationships" => {
               "photographer" => nil
@@ -84,15 +86,12 @@ RSpec.describe(JSONAPI::Realizer::Resource) do
       end
 
       before do
-        Account.create!(:id => 9, :name => "Dan Gebhardt", :twitter => "dgeb")
+        account = Account.create!(:id => 9, :name => "Dan Gebhardt", :twitter => "dgeb")
+        Photo.create!(:id => 11, :photographer => account, :title => "Ember Hamster", :src => "http://example.com/images/productivity.png")
       end
 
       it "object is a Photo" do
         expect(subject.object).to be_kind_of(Photo)
-      end
-
-      it "object isn't saved" do
-        expect(subject.object).to_not be_persisted()
       end
 
       it "clears relationship on realizing nil" do

--- a/lib/jsonapi/realizer/resource_spec.rb
+++ b/lib/jsonapi/realizer/resource_spec.rb
@@ -58,6 +58,46 @@ RSpec.describe(JSONAPI::Realizer::Resource) do
           :src => "http://example.com/images/productivity.png"
         )
       end
+
+      it "has a photographer" do
+        expect(subject.object.photographer).not_to be_nil
+      end
+    end
+
+    context "when specifying nil relationship" do
+      let(:intent) {:create}
+      let(:parameters) do
+        {
+          "data" => {
+            "type" => "photos",
+            "relationships" => {
+              "photographer" => nil
+            }
+          }
+        }
+      end
+      let(:headers) do
+        {
+          "Accept" => "application/vnd.api+json",
+          "Content-Type" => "application/vnd.api+json"
+        }
+      end
+
+      before do
+        Account.create!(:id => 9, :name => "Dan Gebhardt", :twitter => "dgeb")
+      end
+
+      it "object is a Photo" do
+        expect(subject.object).to be_kind_of(Photo)
+      end
+
+      it "object isn't saved" do
+        expect(subject.object).to_not be_persisted()
+      end
+
+      it "clears relationship on realizing nil" do
+        expect(subject.object.photographer).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
Heyo! So this was the inspiration to make the recent changes to https://github.com/krainboltgreene/smart_params.rb allowing params to be nullable: clearing relationships. This little patch allows this. I've included a test as well. Would love your input. Thanks man.